### PR TITLE
fix PriceAmountCents type

### DIFF
--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -216,7 +216,7 @@ func resourcePaymentMethodUpdateFunc(ctx context.Context, d *schema.ResourceData
 				PaymentSourceType: stringRef(attributes["payment_source_type"]),
 				CurrencyCode:      stringRef(attributes["currency_code"]),
 				Moto:              boolRef(attributes["moto"]),
-				PriceAmountCents:  intToInt32Ref(attributes["price_amount_cents"]),
+				PriceAmountCents:  int32(attributes["price_amount_cents"].(int)),
 				Reference:         stringRef(attributes["reference"]),
 				ReferenceOrigin:   stringRef(attributes["reference_origin"]),
 				Metadata:          keyValueRef(attributes["metadata"]),


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

This change ensures that `PriceAmountCents` is an integer even if the value is 0.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

-->

Fixes #18 

<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

-  
