### PR TITLE
Fix: update payment method resource fields

### DIFF
--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -97,13 +97,11 @@ func resourcePaymentMethod() *schema.Resource {
 							Description: "Send this attribute if you want to mark this resource as disabled.",
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     false,
 						},
 						"_enable": {
 							Description: "Send this attribute if you want to mark this resource as enabled.",
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     true,
 						},
 						"reference": {
 							Description: "A string that you can use to add any external identifier to the resource. This " +
@@ -183,6 +181,7 @@ func resourcePaymentMethodCreateFunc(ctx context.Context, d *schema.ResourceData
 		Data: commercelayer.PaymentMethodCreateData{
 			Type: paymentMethodType,
 			Attributes: commercelayer.POSTPaymentMethods201ResponseDataAttributes{
+				Name:        			   stringRef(attributes["name"]),
 				PaymentSourceType:         attributes["payment_source_type"].(string),
 				CurrencyCode:              stringRef(attributes["currency_code"]),
 				Moto:                      boolRef(attributes["moto"]),
@@ -259,6 +258,7 @@ func resourcePaymentMethodUpdateFunc(ctx context.Context, d *schema.ResourceData
 			Type: paymentMethodType,
 			Id:   d.Id(),
 			Attributes: commercelayer.PATCHPaymentMethodsPaymentMethodId200ResponseDataAttributes{
+				Name:        			   stringRef(attributes["name"]),
 				PaymentSourceType:         stringRef(attributes["payment_source_type"]),
 				CurrencyCode:              stringRef(attributes["currency_code"]),
 				Moto:                      boolRef(attributes["moto"]),

--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -39,18 +39,18 @@ func resourcePaymentMethod() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Description:      "The payment method's internal name.",
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: paymentSourceValidation,
+							Description: "The payment method's internal name.",
+							Type:        schema.TypeString,
+							Optional:    true,
 						},
 						"payment_source_type": {
 							Description: "The payment source type, can be one of: 'adyen_payments', " +
 								"'axerve_payments', 'braintree_payments', 'checkout_com_payments', 'credit_cards', " +
 								"'external_payments', 'klarna_payments', 'paypal_payments', 'satispay_payments', " +
 								"'stripe_payments', or 'wire_transfers'",
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: paymentSourceValidation,
 						},
 						"currency_code": {
 							Description: "The international 3-letter currency code as defined by the ISO 4217 standard. " +
@@ -181,7 +181,7 @@ func resourcePaymentMethodCreateFunc(ctx context.Context, d *schema.ResourceData
 		Data: commercelayer.PaymentMethodCreateData{
 			Type: paymentMethodType,
 			Attributes: commercelayer.POSTPaymentMethods201ResponseDataAttributes{
-				Name:        			   stringRef(attributes["name"]),
+				Name:                      stringRef(attributes["name"]),
 				PaymentSourceType:         attributes["payment_source_type"].(string),
 				CurrencyCode:              stringRef(attributes["currency_code"]),
 				Moto:                      boolRef(attributes["moto"]),
@@ -258,7 +258,7 @@ func resourcePaymentMethodUpdateFunc(ctx context.Context, d *schema.ResourceData
 			Type: paymentMethodType,
 			Id:   d.Id(),
 			Attributes: commercelayer.PATCHPaymentMethodsPaymentMethodId200ResponseDataAttributes{
-				Name:        			   stringRef(attributes["name"]),
+				Name:                      stringRef(attributes["name"]),
 				PaymentSourceType:         stringRef(attributes["payment_source_type"]),
 				CurrencyCode:              stringRef(attributes["currency_code"]),
 				Moto:                      boolRef(attributes["moto"]),

--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -38,14 +38,19 @@ func resourcePaymentMethod() *schema.Resource {
 				Required:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"name": {
+							Description:      "The payment method's internal name.",
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: paymentSourceValidation,
+						},
 						"payment_source_type": {
 							Description: "The payment source type, can be one of: 'adyen_payments', " +
 								"'axerve_payments', 'braintree_payments', 'checkout_com_payments', 'credit_cards', " +
 								"'external_payments', 'klarna_payments', 'paypal_payments', 'satispay_payments', " +
 								"'stripe_payments', or 'wire_transfers'",
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: paymentSourceValidation,
+							Type:     schema.TypeString,
+							Required: true,
 						},
 						"currency_code": {
 							Description: "The international 3-letter currency code as defined by the ISO 4217 standard. " +
@@ -60,10 +65,45 @@ func resourcePaymentMethod() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"require_capture": {
+							Description: "Send this attribute if you want to require the payment capture before fulfillment.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+						},
+						"auto_place": {
+							Description: "Send this attribute if you want to automatically place the order upon authorization performed asynchronously.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"auto_capture": {
+							Description: "Send this attribute if you want to automatically capture the payment upon authorization.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
 						"price_amount_cents": {
 							Description: "The payment method's price, in cents.",
 							Type:        schema.TypeInt,
 							Required:    true,
+						},
+						"auto_capture_max_amount_cents": {
+							Description: "Send this attribute if you want to limit automatic capture to orders for which the total amount is equal or less than the specified value, in cents.",
+							Type:        schema.TypeInt,
+							Optional:    true,
+						},
+						"_disable": {
+							Description: "Send this attribute if you want to mark this resource as disabled.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"_enable": {
+							Description: "Send this attribute if you want to mark this resource as enabled.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
 						},
 						"reference": {
 							Description: "A string that you can use to add any external identifier to the resource. This " +
@@ -143,13 +183,19 @@ func resourcePaymentMethodCreateFunc(ctx context.Context, d *schema.ResourceData
 		Data: commercelayer.PaymentMethodCreateData{
 			Type: paymentMethodType,
 			Attributes: commercelayer.POSTPaymentMethods201ResponseDataAttributes{
-				PaymentSourceType: attributes["payment_source_type"].(string),
-				CurrencyCode:      stringRef(attributes["currency_code"]),
-				Moto:              boolRef(attributes["moto"]),
-				PriceAmountCents:  int32(attributes["price_amount_cents"].(int)),
-				Reference:         stringRef(attributes["reference"]),
-				ReferenceOrigin:   stringRef(attributes["reference_origin"]),
-				Metadata:          keyValueRef(attributes["metadata"]),
+				PaymentSourceType:         attributes["payment_source_type"].(string),
+				CurrencyCode:              stringRef(attributes["currency_code"]),
+				Moto:                      boolRef(attributes["moto"]),
+				PriceAmountCents:          int32(attributes["price_amount_cents"].(int)),
+				RequireCapture:            boolRef(attributes["require_capture"]),
+				AutoPlace:                 boolRef(attributes["auto_place"]),
+				AutoCapture:               boolRef(attributes["auto_capture"]),
+				AutoCaptureMaxAmountCents: int32(attributes["auto_capture_max_amount_cents"].(int)),
+				Disable:                   boolRef(attributes["_disable"]),
+				Enable:                    boolRef(attributes["_enable"]),
+				Reference:                 stringRef(attributes["reference"]),
+				ReferenceOrigin:           stringRef(attributes["reference_origin"]),
+				Metadata:                  keyValueRef(attributes["metadata"]),
 			},
 			Relationships: &commercelayer.PaymentMethodCreateDataRelationships{
 				PaymentGateway: commercelayer.PaymentMethodCreateDataRelationshipsPaymentGateway{
@@ -213,13 +259,19 @@ func resourcePaymentMethodUpdateFunc(ctx context.Context, d *schema.ResourceData
 			Type: paymentMethodType,
 			Id:   d.Id(),
 			Attributes: commercelayer.PATCHPaymentMethodsPaymentMethodId200ResponseDataAttributes{
-				PaymentSourceType: stringRef(attributes["payment_source_type"]),
-				CurrencyCode:      stringRef(attributes["currency_code"]),
-				Moto:              boolRef(attributes["moto"]),
-				PriceAmountCents:  int32(attributes["price_amount_cents"].(int)),
-				Reference:         stringRef(attributes["reference"]),
-				ReferenceOrigin:   stringRef(attributes["reference_origin"]),
-				Metadata:          keyValueRef(attributes["metadata"]),
+				PaymentSourceType:         stringRef(attributes["payment_source_type"]),
+				CurrencyCode:              stringRef(attributes["currency_code"]),
+				Moto:                      boolRef(attributes["moto"]),
+				PriceAmountCents:          int32(attributes["price_amount_cents"].(int)),
+				RequireCapture:            boolRef(attributes["require_capture"]),
+				AutoPlace:                 boolRef(attributes["auto_place"]),
+				AutoCapture:               boolRef(attributes["auto_capture"]),
+				AutoCaptureMaxAmountCents: int32(attributes["auto_capture_max_amount_cents"].(int)),
+				Disable:                   boolRef(attributes["_disable"]),
+				Enable:                    boolRef(attributes["_enable"]),
+				Reference:                 stringRef(attributes["reference"]),
+				ReferenceOrigin:           stringRef(attributes["reference_origin"]),
+				Metadata:                  keyValueRef(attributes["metadata"]),
 			},
 			Relationships: &commercelayer.PaymentMethodUpdateDataRelationships{
 				PaymentGateway: &commercelayer.PaymentMethodCreateDataRelationshipsPaymentGateway{

--- a/commercelayer/resource_payment_method_test.go
+++ b/commercelayer/resource_payment_method_test.go
@@ -70,17 +70,26 @@ func (s *AcceptanceSuite) TestAccPaymentMethod_basic() {
 				Config: strings.Join([]string{testAccAdyenGatewayCreate(resourceName), testAccPaymentMethodCreate(resourceName)}, "\n"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", paymentMethodType),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Adyen"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.metadata.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.currency_code", "EUR"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.payment_source_type", "AdyenPayment"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.price_amount_cents", "10"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.require_capture", "true"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_place", "false"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_capture", "false"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_capture_max_amount_cents", "100"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0._disable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0._enable", "true"),
 				),
 			},
 			{
 				Config: strings.Join([]string{testAccAdyenGatewayCreate(resourceName), testAccPaymentMethodUpdate(resourceName)}, "\n"),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Adyen Payment"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.metadata.bar", "foo"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.price_amount_cents", "5"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0._disable", "true"),
 				),
 			},
 		},
@@ -92,8 +101,11 @@ func testAccPaymentMethodCreate(testName string) string {
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
       		payment_source_type   = "AdyenPayment"
+			name 				  =	"Adyen"
 			currency_code          = "EUR"
 			price_amount_cents     = 10
+			require_capture = true
+			auto_capture_max_amount_cents = 100
 			metadata               = {
 			  foo : "bar"
 		 	  testName: "{{.testName}}"
@@ -111,9 +123,11 @@ func testAccPaymentMethodUpdate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
+		    name 				   = "Adyen Payment"
       		payment_source_type    = "AdyenPayment"
 			currency_code          = "EUR"
 			price_amount_cents     = 5
+			_disable			   = true
 			metadata               = {
 			  bar : "foo"
 		 	  testName: "{{.testName}}"

--- a/commercelayer/resource_payment_method_test.go
+++ b/commercelayer/resource_payment_method_test.go
@@ -79,17 +79,14 @@ func (s *AcceptanceSuite) TestAccPaymentMethod_basic() {
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_place", "false"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_capture", "false"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_capture_max_amount_cents", "100"),
-					resource.TestCheckResourceAttr(resourceName, "attributes.0._disable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "attributes.0._enable", "true"),
 				),
 			},
 			{
 				Config: strings.Join([]string{testAccAdyenGatewayCreate(resourceName), testAccPaymentMethodUpdate(resourceName)}, "\n"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Adyen Payment"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Adyen Payment Method"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.metadata.bar", "foo"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.price_amount_cents", "5"),
-					resource.TestCheckResourceAttr(resourceName, "attributes.0._disable", "true"),
 				),
 			},
 		},
@@ -100,13 +97,13 @@ func testAccPaymentMethodCreate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
-      		payment_source_type   = "AdyenPayment"
-			name 				  =	"Adyen"
-			currency_code          = "EUR"
-			price_amount_cents     = 10
-			require_capture = true
-			auto_capture_max_amount_cents = 100
-			metadata               = {
+      		payment_source_type  		 	= "AdyenPayment"
+			name 				 		 	= "Adyen"
+			currency_code        			= "EUR"
+			price_amount_cents 			 	= 10
+			require_capture      		 	= true
+			auto_capture_max_amount_cents	= 100
+			metadata               			= {
 			  foo : "bar"
 		 	  testName: "{{.testName}}"
 			}
@@ -123,7 +120,7 @@ func testAccPaymentMethodUpdate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
-		    name 				   = "Adyen Payment"
+		    name 				   = "Adyen Payment Method"
       		payment_source_type    = "AdyenPayment"
 			currency_code          = "EUR"
 			price_amount_cents     = 5

--- a/commercelayer/resource_payment_method_test.go
+++ b/commercelayer/resource_payment_method_test.go
@@ -97,11 +97,11 @@ func testAccPaymentMethodCreate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
-      		payment_source_type  		 	= "AdyenPayment"
-			name 				 		 	= "Adyen"
-			currency_code        			= "EUR"
-			price_amount_cents 			 	= 10
-			require_capture      		 	= true
+			payment_source_type				= "AdyenPayment"
+			name							= "Adyen"
+			currency_code					= "EUR"
+			price_amount_cents				= 10
+			require_capture					= true
 			auto_capture_max_amount_cents	= 100
 			metadata               			= {
 			  foo : "bar"
@@ -120,14 +120,14 @@ func testAccPaymentMethodUpdate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
-		    name 				   = "Adyen Payment Method"
-      		payment_source_type    = "AdyenPayment"
-			currency_code          = "EUR"
-			price_amount_cents     = 5
-			_disable			   = true
-			metadata               = {
+			name					= "Adyen Payment Method"
+			payment_source_type		= "AdyenPayment"
+			currency_code			= "EUR"
+			price_amount_cents		= 5
+			_disable				= true
+			metadata				= {
 			  bar : "foo"
-		 	  testName: "{{.testName}}"
+			  testName: "{{.testName}}"
 			}
 		  }
   		  relationships {

--- a/examples/resources/commercelayer_payment_method/resource.tf
+++ b/examples/resources/commercelayer_payment_method/resource.tf
@@ -10,10 +10,15 @@ resource "commercelayer_adyen_gateway" "labd_adyen_gateway" {
 
 resource "commercelayer_payment_method" "labd_payment_method" {
   attributes {
+    name                          = "Adyen Payment Method"
     payment_source_type           = "AdyenPayment"
+    require_capture               = true
+    auto_place                    = true 
+    auto_capture                  = true
+    reference                     = "internal-payment-ref"
     currency_code                 = "EUR"
     price_amount_cents            = 0
-    auto_capture_max_amount_cents = 100
+    auto_capture_max_amount_cents = 10000
   }
 
   relationships {

--- a/examples/resources/commercelayer_payment_method/resource.tf
+++ b/examples/resources/commercelayer_payment_method/resource.tf
@@ -10,9 +10,10 @@ resource "commercelayer_adyen_gateway" "labd_adyen_gateway" {
 
 resource "commercelayer_payment_method" "labd_payment_method" {
   attributes {
-    payment_source_type = "AdyenPayment"
-    currency_code       = "EUR"
-    price_amount_cents  = 0
+    payment_source_type           = "AdyenPayment"
+    currency_code                 = "EUR"
+    price_amount_cents            = 0
+    auto_capture_max_amount_cents = 100
   }
 
   relationships {


### PR DESCRIPTION
Add attributes to `payment_method` resource #21 

- name: The payment method's internal name.
- require_capture: Whether payment capture is required before fulfillment.
- auto_place: Automatically place the order upon asynchronous authorization.
- auto_capture: Automatically capture the payment upon authorization.
- auto_capture_max_amount_cents: Limit automatic capture to orders with a total amount equal to or less than this value (in cents).
- _disable: Mark this resource as disabled.
- _enable: Mark this resource as enabled.



