### PR TITLE
Fix: set payment_method attributes in TF state to make lifecycle.ignore_changes work

### DIFF
--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -160,13 +160,32 @@ func resourcePaymentMethodReadFunc(ctx context.Context, d *schema.ResourceData, 
 		return diagErr(err)
 	}
 
-	address, ok := resp.GetDataOk()
+	paymentMethod, ok := resp.GetDataOk()
 	if !ok {
 		d.SetId("")
 		return nil
 	}
 
-	d.SetId(address.GetId().(string))
+	d.SetId(paymentMethod.GetId().(string))
+
+	attrs := map[string]interface{}{
+		"name":                          paymentMethod.Attributes.GetName(),
+		"payment_source_type":           paymentMethod.Attributes.GetPaymentSourceType(),
+		"currency_code":                 paymentMethod.Attributes.GetCurrencyCode(),
+		"moto":                          paymentMethod.Attributes.GetMoto(),
+		"price_amount_cents":            paymentMethod.Attributes.GetPriceAmountCents(),
+		"require_capture":               paymentMethod.Attributes.GetRequireCapture(),
+		"auto_place":                    paymentMethod.Attributes.GetAutoPlace(),
+		"auto_capture":                  paymentMethod.Attributes.GetAutoCapture(),
+		"auto_capture_max_amount_cents": paymentMethod.Attributes.GetAutoCaptureMaxAmountCents(),
+		"reference":                     paymentMethod.Attributes.GetReference(),
+		"reference_origin":              paymentMethod.Attributes.GetReferenceOrigin(),
+		"metadata":                      paymentMethod.Attributes.GetMetadata(),
+	}
+
+	if err := d.Set("attributes", []interface{}{attrs}); err != nil {
+		return diagErr(err)
+	}
 
 	return nil
 }

--- a/commercelayer/resource_payment_method.go
+++ b/commercelayer/resource_payment_method.go
@@ -183,6 +183,13 @@ func resourcePaymentMethodReadFunc(ctx context.Context, d *schema.ResourceData, 
 		"metadata":                      paymentMethod.Attributes.GetMetadata(),
 	}
 
+	if v, ok := d.GetOk("attributes.0._disable"); ok {
+		attrs["_disable"] = v
+	}
+	if v, ok := d.GetOk("attributes.0._enable"); ok {
+		attrs["_enable"] = v
+	}
+
 	if err := d.Set("attributes", []interface{}{attrs}); err != nil {
 		return diagErr(err)
 	}

--- a/commercelayer/resource_payment_method_test.go
+++ b/commercelayer/resource_payment_method_test.go
@@ -73,7 +73,7 @@ func (s *AcceptanceSuite) TestAccPaymentMethod_basic() {
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.name", "Adyen"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.metadata.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.currency_code", "EUR"),
-					resource.TestCheckResourceAttr(resourceName, "attributes.0.payment_source_type", "AdyenPayment"),
+					resource.TestCheckResourceAttr(resourceName, "attributes.0.payment_source_type", "adyen_payments"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.price_amount_cents", "10"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.require_capture", "true"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0.auto_place", "false"),
@@ -97,7 +97,7 @@ func testAccPaymentMethodCreate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
-			payment_source_type				= "AdyenPayment"
+			payment_source_type				= "adyen_payments"
 			name							= "Adyen"
 			currency_code					= "EUR"
 			price_amount_cents				= 10
@@ -121,7 +121,7 @@ func testAccPaymentMethodUpdate(testName string) string {
 		resource "commercelayer_payment_method" "labd_payment_method" {
 		  attributes {
 			name					= "Adyen Payment Method"
-			payment_source_type		= "AdyenPayment"
+			payment_source_type		= "adyen_payments"
 			currency_code			= "EUR"
 			price_amount_cents		= 5
 			_disable				= true


### PR DESCRIPTION
* During the read of the `payment_method` resource, set the current metadata value to the Terraform state to allow Terraform to detect state drift in that field and to ignore it if the field is present in the lifecycle.ignore_changes argument. Without this, Terraform will always set metadata to an empty map{}, clearing any changes that were done outside of Terraform.
* Also added the remaining attributes for the same reason.
* Read and set _enable and _disable attributes from state since these are not returned from CommerceLayer API but are needed to determine if an update is needed if a change is made to the _enable or _disable attributes


Fixes #25  
